### PR TITLE
Fix warnings for wp_upload_dir on read-only filesystem

### DIFF
--- a/themegrill-demo-importer.php
+++ b/themegrill-demo-importer.php
@@ -76,7 +76,7 @@ final class ThemeGrill_Demo_Importer {
 	 * Define TGDM Constants.
 	 */
 	private function define_constants() {
-		$upload_dir = wp_upload_dir();
+		$upload_dir = wp_upload_dir( null, false );
 
 		$this->define( 'TGDM_PLUGIN_FILE', __FILE__ );
 		$this->define( 'TGDM_ABSPATH', dirname( TGDM_PLUGIN_FILE ) . '/' );


### PR DESCRIPTION
This fixes an issue where the define_constants routing would give a warning on every page load on a read-only filesystem.

By default `wp_upload_dir` will try and create the folder if it does not exist, passing false to the create param will avoid this. We simply want the location, not try and create it when defining constants.