### PR TITLE
Updates URL to resources

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,7 @@
 == Changelog ==
+= TBD =
+* Tweak - Updates resources URL.
+
 = 1.7.5 - 25-10-2021 =
 * Tweak - Use of escaping and sanitization functions.
 

--- a/includes/admin/class-demo-importer-status.php
+++ b/includes/admin/class-demo-importer-status.php
@@ -53,7 +53,7 @@ class TG_Demo_Importer_Status {
 	 */
 	public static function get_demo_server_connection_status() {
 		$output              = '';
-		$package_file_server = wp_remote_get( 'https://github.com/' );
+		$package_file_server = wp_remote_get( 'https://themegrill-demo-pack.s3.us-east-2.amazonaws.com/README.md' );
 		$http_response_code  = wp_remote_retrieve_response_code( $package_file_server );
 
 		if ( is_wp_error( $package_file_server ) || 200 !== (int) $http_response_code ) {

--- a/includes/class-demo-importer.php
+++ b/includes/class-demo-importer.php
@@ -89,7 +89,7 @@ class TG_Demo_Importer {
 		$template = strtolower( str_replace( '-pro', '', get_option( 'template' ) ) );
 
 		if ( false === $packages || ( isset( $packages->slug ) && $template !== $packages->slug ) ) {
-			$raw_packages = wp_safe_remote_get( "https://raw.githubusercontent.com/themegrill/themegrill-demo-pack/master/configs/{$template}.json" );
+			$raw_packages = wp_safe_remote_get( "https://themegrill-demo-pack.s3.us-east-2.amazonaws.com/configs/{$template}.json" );
 
 			if ( ! is_wp_error( $raw_packages ) ) {
 				$packages = json_decode( wp_remote_retrieve_body( $raw_packages ) );
@@ -417,7 +417,7 @@ class TG_Demo_Importer {
 		if ( isset( $available_packages->demos ) ) {
 			foreach ( $available_packages->demos as $package_slug => $package_data ) {
 				$plugins_list   = isset( $package_data->plugins_list ) ? $package_data->plugins_list : array();
-				$screenshot_url = "https://raw.githubusercontent.com/themegrill/themegrill-demo-pack/master/resources/{$available_packages->slug}/{$package_slug}/screenshot.jpg";
+				$screenshot_url = "https://themegrill-demo-pack.s3.us-east-2.amazonaws.com/resources/{$available_packages->slug}/{$package_slug}/screenshot.jpg";
 
 				if ( isset( $request['browse'], $package_data->category ) && ! in_array( $request['browse'], $package_data->category, true ) ) {
 					continue;
@@ -684,7 +684,7 @@ class TG_Demo_Importer {
 		$upgrader = new TG_Demo_Pack_Upgrader( $skin );
 		$template = strtolower( str_replace( '-pro', '', get_option( 'template' ) ) );
 		$packages = isset( $this->demo_packages->demos ) ? json_decode( wp_json_encode( $this->demo_packages->demos ), true ) : array();
-		$result   = $upgrader->install( "https://github.com/themegrill/themegrill-demo-pack/raw/master/packages/{$template}/{$slug}.zip" );
+		$result   = $upgrader->install( "https://themegrill-demo-pack.s3.us-east-2.amazonaws.com/packages/{$template}/{$slug}.zip" );
 
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			$status['debug'] = $skin->get_upgrade_messages();

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,9 @@ Yes you can! Join in on our [GitHub repository](https://github.com/themegrill/th
 3. Finally, Import the Demo with just one click.
 
 == Changelog ==
+= TBD =
+* Tweak - Updates resources URL.
+
 = 1.7.5 - 25-10-2021 =
 * Tweak - Use of escaping and sanitization functions.
 

--- a/readme.txt
+++ b/readme.txt
@@ -15,6 +15,10 @@ Import <a href="https://themegrill.com/themes/" target="_blank" rel="nofollow">T
 
 Get [free support](https://themegrill.com/support-forum/)
 
+== Notes ==
+
+* The plugin makes a call to our S3 server remotely to import static demo content.
+
 = Demo Importer in action: =
 
 [youtube https://youtu.be/cXxmpNIui9Y]


### PR DESCRIPTION
# Changes proposed in this Pull Request
- Updates resources URL from: https://raw.githubusercontent.com/themegrill/themegrill-demo-pack, to: https://themegrill-demo-pack.s3.us-east-2.amazonaws.com

## Steps to Test this PR
- Make sure the old URL is not used for loading resources while importing demos. You can test with the help of the browser inspector tool.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
# Checklist:
- [x] My code follows the WordPress' coding standards
- [x] I've checked to ensure there aren't other open Pull Requests for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have made performed tests that prove my fix is effective or that my feature works
# Did you test this issue fix on all browsers?
- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Internet Explorer
## Changelog entry
* Tweak - Updates resources URL.