### PR TITLE
CMAG-677 Colormag main demo import issue fix

### DIFF
--- a/src/ImportHooks.php
+++ b/src/ImportHooks.php
@@ -618,9 +618,11 @@ class ImportHooks {
 
 			// Update the post content.
 			wp_update_post(
-				array(
-					'ID'           => $post_id,
-					'post_content' => $post_content,
+				wp_slash(
+					array(
+						'ID'           => $post_id,
+						'post_content' => $post_content,
+					)
 				)
 			);
 		}


### PR DESCRIPTION
fix: wp_slash() post content before wp_update_post() in process_evf_posts

Re-serializing block content via serialize_blocks() re-escapes literal "--" back to --, but the result was passed to wp_update_post() unslashed. WordPress's internal unslash step then stripped the backslash entirely, permanently corrupting CSS var(--...) references in any imported post/page that also contains an Everest Forms block.